### PR TITLE
Remove insecure `trusted-users`

### DIFF
--- a/modules/base/nix/nix.nix
+++ b/modules/base/nix/nix.nix
@@ -49,8 +49,6 @@ in
 
       # users or groups which are allowed to do anything with the Nix daemon
       allowed-users = [ sudoers ];
-      # users or groups which are allowed to manage the nix store
-      trusted-users = [ sudoers ];
 
       # we don't want to track the registry, but we do want to allow the usage
       # of the `flake:` references, so we need to enable use-registries


### PR DESCRIPTION
`trusted-users` gives root without password, and you probably don't need it. use `substituters` etc to set fine grained options instead. 
doc: https://docs.lix.systems/manual/lix/stable/command-ref/conf-file.html#conf-trusted-users
exploit: https://github.com/NixOS/nix/issues/9649#issuecomment-1868001568
the doc doesn't do it justice, you can easily run arbitrary commands as root.

