### PR TITLE
Revert nix trusted users

### DIFF
--- a/modules/base/nix/nix.nix
+++ b/modules/base/nix/nix.nix
@@ -49,6 +49,8 @@ in
 
       # users or groups which are allowed to do anything with the Nix daemon
       allowed-users = [ sudoers ];
+      # users or groups which are allowed to manage the nix store
+      trusted-users = [ sudoers ];
 
       # we don't want to track the registry, but we do want to allow the usage
       # of the `flake:` references, so we need to enable use-registries

--- a/modules/base/nix/nix.nix
+++ b/modules/base/nix/nix.nix
@@ -8,6 +8,8 @@
 }:
 let
   inherit (lib.lists) optionals;
+
+  sudoers = if (_class == "nixos") then "@wheel" else "@admin";
 in
 {
   nix = {
@@ -46,9 +48,7 @@ in
       auto-optimise-store = true;
 
       # users or groups which are allowed to do anything with the Nix daemon
-      # in the past trusted-users was also set but that's the same as adding a root
-      # user, so lets not do that!
-      allowed-users = [ (if (_class == "nixos") then "@wheel" else "@admin") ];
+      allowed-users = [ sudoers ];
 
       # we don't want to track the registry, but we do want to allow the usage
       # of the `flake:` references, so we need to enable use-registries


### PR DESCRIPTION
seems needed 

> Note: When rebuilding a remote host, you may see similar errors to the following:
       error: cannot add path '/nix/store/...' because it lacks a signature by a trusted key
> If this occurs, add your non-root user or group to the trusted-users list in /etc/nix/nix.conf, which is the nix.settings.trusted-users option in NixOS. Please note that this is equivalent to having root access, [as described in the Nix manual](https://nix.dev/manual/nix/2.34/command-ref/conf-file.html#conf-trusted-users).